### PR TITLE
Accept spaces in code runs

### DIFF
--- a/eofparse/main.go
+++ b/eofparse/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -19,7 +20,8 @@ func work() {
 	var c vm.Container
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
-		blob := common.FromHex(scanner.Text())
+		code := strings.Replace(scanner.Text(), " ", "", -1)
+		blob := common.FromHex(code)
 		err := c.UnmarshalBinary(blob)
 		if err != nil {
 			fmt.Printf("err: %v\n", err)

--- a/eofparse/main.go
+++ b/eofparse/main.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"strings"
+	"regexp"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -18,9 +18,10 @@ func work() {
 	// The input is assumed to be an EOF1 container verified against Shanghain instructionset.
 	jt := vm.NewShanghaiEOFInstructionSetForTesting()
 	var c vm.Container
+	notAlphaNum := regexp.MustCompile(`[^0-9A-Za-z]`)
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
-		code := strings.Replace(scanner.Text(), " ", "", -1)
+		code := notAlphaNum.ReplaceAllString(scanner.Text(), "")
 		blob := common.FromHex(code)
 		err := c.UnmarshalBinary(blob)
 		if err != nil {


### PR DESCRIPTION
For stdin remove all non-alphanumerics from input so code runs can be clarified with punctuation.

Signed-off-by: Danno Ferrin <danno.ferrin@swirldslabs.com>